### PR TITLE
Ignore not committed files and sort results

### DIFF
--- a/html.sh
+++ b/html.sh
@@ -3,7 +3,7 @@
 echo '<html>' > index.html
 echo '<head><title>mvn.opencast.org</title></head>' >> index.html
 echo '<body><h1>mvn.opencast.org</h1><ul>' >> index.html
-for f in $(find com org -type f); do
+for f in $(git ls-files com org | sort); do
 	echo "<li><a href='${f}'>${f}</a></li>" >> index.html
 done
 echo '</ul></body></html>' >> index.html


### PR DESCRIPTION
Using `find` will include files created by the operating system (e.g. `.DS_Store` on macOS). Instead, `git` has a custom command for listing files in the repository (including files in the staging area).

I included `sort` such that the diffs are easier to read.